### PR TITLE
Use notfounds/changesets-action to set labels

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,9 +27,10 @@ jobs:
         run: yarn
 
       - name: Create Release Pull Request
-        uses: changesets/action@v1
+        uses: notfounds/changesets-action@feat-enable-to-add-labels
         with:
           publish: yarn changeset publish
+          labels: "release"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
There is no way to add labels to release PR on changesets/action creates.

I implemented an option to attach labels to a release PR in https://github.com/NotFounds/changesets-action/pull/1.

So this is an experiment.